### PR TITLE
Fix data loss when saving menu and promotions

### DIFF
--- a/pages/api/clients/[clientId]/menu.ts
+++ b/pages/api/clients/[clientId]/menu.ts
@@ -20,7 +20,11 @@ const getMenuItems = (dataPath: string) => {
 };
 
 const saveMenuItems = (dataPath: string, menuItems: any) => {
-  const data = { menuItems };
+  let existingData = {};
+  if (fs.existsSync(dataPath)) {
+    existingData = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  }
+  const data = { ...existingData, menuItems };
   fs.writeFileSync(dataPath, JSON.stringify(data, null, 2));
 };
 
@@ -47,7 +51,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method === 'GET') {
     try {
       const menuItems = getMenuItems(dataPath);
-      res.status(200).json(menuItems);
+      res.status(200).json({ menuItems });
     } catch (error) {
       res.status(500).json({ message: 'Erro ao carregar os itens do menu' });
     }

--- a/pages/api/clients/[clientId]/promotions.ts
+++ b/pages/api/clients/[clientId]/promotions.ts
@@ -13,7 +13,11 @@ const getPromotionItems = (dataPath: string) => {
 };
 
 const savePromotionItems = (dataPath: string, promotionItems: any) => {
-  const data = { promotionItems };
+  let existingData = {};
+  if (fs.existsSync(dataPath)) {
+    existingData = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  }
+  const data = { ...existingData, promotionItems };
   fs.writeFileSync(dataPath, JSON.stringify(data, null, 2));
 };
 
@@ -40,7 +44,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method === 'GET') {
     try {
       const promotionItems = getPromotionItems(dataPath);
-      res.status(200).json(promotionItems);
+      res.status(200).json({ promotionItems });
     } catch (error) {
       res.status(500).json({ message: 'Erro ao carregar os itens de promoção' });
     }


### PR DESCRIPTION
## Summary
- ensure API handlers merge existing data before writing
- return objects with `menuItems` or `promotionItems` in API responses

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e2b4d7a4832db55557601efaaaf4