### PR TITLE
Implement simple order API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Orders API
+
+A new endpoint `/api/clients/[clientId]/orders` allows creation and listing of customer orders. `POST` saves an order in the client's JSON file and `GET` returns all orders.
+
+

--- a/README.md
+++ b/README.md
@@ -39,4 +39,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 
 A new endpoint `/api/clients/[clientId]/orders` allows creation and listing of customer orders. `POST` saves an order in the client's JSON file and `GET` returns all orders.
 
+## Clients API
+
+`GET /api/clients` returns the list of available client IDs based on the JSON files stored in the `data` directory.
+
+## Login API
+
+`POST /api/login` checks credentials sent as `{ usuario, password }` against `Cadastro.json` and returns the user data on success.
+
 

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useState, ReactNode } from 'react';
 import { useRouter } from 'next/router';
-import cadastroData from '../data/Cadastro.json';
 
 interface Cadastro {
   id: number;
@@ -52,20 +51,30 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [loggedUser, setLoggedUser] = useState<Cadastro | null>(null);
   const router = useRouter();
 
-  const login = (clientId: string, username: string, password: string) => {
-    const user: Cadastro | undefined = cadastroData.Cadastro.find((user: Cadastro) => user.usuario === username);
+  const login = async (client: string, username: string, password: string) => {
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ usuario: username, password }),
+      });
 
-    if (user && user.password === password) {
-      setIsAuthenticated(true);
-      setClientId(clientId);
-      setLoggedUser(normalizeCadastro(user));
-      if (router.pathname.includes('/admin')) {
-        router.push(`/clients/${clientId}/admin`);
-      } else {
-        router.push(`/clients/${clientId}/home`);
+      if (!res.ok) {
+        alert('Invalid credentials');
+        return;
       }
-    } else {
-      alert('Invalid credentials');
+
+      const data = await res.json();
+      setIsAuthenticated(true);
+      setClientId(client);
+      setLoggedUser(normalizeCadastro(data.user));
+      if (router.pathname.includes('/admin')) {
+        router.push(`/clients/${client}/admin`);
+      } else {
+        router.push(`/clients/${client}/home`);
+      }
+    } catch {
+      alert('Erro ao fazer login');
     }
   };
 

--- a/context/CartContext.tsx
+++ b/context/CartContext.tsx
@@ -15,6 +15,7 @@ interface CartContextType {
   cart: CartItem[];
   addToCart: (item: CartItem) => void;
   removeFromCart: (id: number, type: 'menu' | 'promotion', quantity?: number) => void;
+  clearCart: () => void;
 }
 
 const CartContext = createContext<CartContextType | undefined>(undefined);
@@ -63,8 +64,12 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
     });
   };
 
+  const clearCart = () => {
+    setCart([]);
+  };
+
   return (
-    <CartContext.Provider value={{ cart, addToCart, removeFromCart }}>
+    <CartContext.Provider value={{ cart, addToCart, removeFromCart, clearCart }}>
       {children}
     </CartContext.Provider>
   );

--- a/data/BullBrothers.json
+++ b/data/BullBrothers.json
@@ -42,5 +42,6 @@
       "image": "/hamburguer/promotion_for_classic_burger.png",
       "category": "burger"
     }
-  ]
+  ],
+  "orders": []
 }

--- a/data/Manarolla.json
+++ b/data/Manarolla.json
@@ -26,5 +26,6 @@
       "image": "/pizza/promotion_for_pizza_margherita.png",
       "category": "pizza"
     }
-  ]
+  ],
+  "orders": []
 }

--- a/data/Oishi.json
+++ b/data/Oishi.json
@@ -32,5 +32,6 @@
       "image": "/sushi/temaki.png",
       "category": "sushi"
     }
-  ]
+  ],
+  "orders": []
 }

--- a/pages/api/clients/[clientId]/menu.ts
+++ b/pages/api/clients/[clientId]/menu.ts
@@ -20,7 +20,10 @@ const getMenuItems = (dataPath: string) => {
 };
 
 const saveMenuItems = (dataPath: string, menuItems: any) => {
-  const data = { menuItems };
+  const data = fs.existsSync(dataPath)
+    ? JSON.parse(fs.readFileSync(dataPath, 'utf8'))
+    : {};
+  data.menuItems = menuItems;
   fs.writeFileSync(dataPath, JSON.stringify(data, null, 2));
 };
 

--- a/pages/api/clients/[clientId]/orders.ts
+++ b/pages/api/clients/[clientId]/orders.ts
@@ -1,0 +1,38 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { clientId } = req.query;
+  const dataPath = path.join(process.cwd(), 'data', `${clientId}.json`);
+
+  if (req.method === 'GET') {
+    try {
+      const data = fs.existsSync(dataPath)
+        ? JSON.parse(fs.readFileSync(dataPath, 'utf8'))
+        : {};
+      const orders = data.orders || [];
+      res.status(200).json(orders);
+    } catch (error) {
+      res.status(500).json({ message: 'Erro ao carregar pedidos' });
+    }
+  } else if (req.method === 'POST') {
+    try {
+      const order = req.body;
+      const data = fs.existsSync(dataPath)
+        ? JSON.parse(fs.readFileSync(dataPath, 'utf8'))
+        : {};
+      const orders = data.orders || [];
+      const newId = orders.length ? orders[orders.length - 1].id + 1 : 1;
+      const newOrder = { ...order, id: newId, date: new Date().toISOString() };
+      orders.push(newOrder);
+      data.orders = orders;
+      fs.writeFileSync(dataPath, JSON.stringify(data, null, 2), 'utf8');
+      res.status(201).json(newOrder);
+    } catch (error) {
+      res.status(500).json({ message: 'Erro ao salvar pedido' });
+    }
+  } else {
+    res.status(405).json({ message: 'Method not allowed' });
+  }
+}

--- a/pages/api/clients/[clientId]/promotions.ts
+++ b/pages/api/clients/[clientId]/promotions.ts
@@ -13,7 +13,10 @@ const getPromotionItems = (dataPath: string) => {
 };
 
 const savePromotionItems = (dataPath: string, promotionItems: any) => {
-  const data = { promotionItems };
+  const data = fs.existsSync(dataPath)
+    ? JSON.parse(fs.readFileSync(dataPath, 'utf8'))
+    : {};
+  data.promotionItems = promotionItems;
   fs.writeFileSync(dataPath, JSON.stringify(data, null, 2));
 };
 

--- a/pages/api/clients/index.ts
+++ b/pages/api/clients/index.ts
@@ -1,0 +1,20 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  try {
+    const dataDir = path.join(process.cwd(), 'data');
+    const files = fs.readdirSync(dataDir);
+    const clients = files
+      .filter(file => file !== 'Cadastro.json')
+      .map(file => file.replace('.json', ''));
+    res.status(200).json(clients);
+  } catch {
+    res.status(500).json({ message: 'Erro ao listar clientes' });
+  }
+}

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -1,0 +1,28 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const { usuario, password } = req.body;
+  if (!usuario || !password) {
+    return res.status(400).json({ message: 'Dados incompletos' });
+  }
+
+  try {
+    const dataPath = path.join(process.cwd(), 'data', 'Cadastro.json');
+    const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+    const user = data.Cadastro.find((u: any) => u.usuario === usuario && u.password === password);
+    if (user) {
+      const { password: _p, ...userData } = user;
+      res.status(200).json({ user: userData });
+    } else {
+      res.status(401).json({ message: 'Credenciais inválidas' });
+    }
+  } catch {
+    res.status(500).json({ message: 'Erro ao verificar usuário' });
+  }
+}

--- a/pages/clients/[clientId]/cart.tsx
+++ b/pages/clients/[clientId]/cart.tsx
@@ -40,7 +40,7 @@ const StyledTypography = styled(Typography)({
 });
 
 const Cart = ({ clientId }: { clientId: string }) => {
-  const { cart, removeFromCart } = useCart();
+  const { cart, removeFromCart, clearCart } = useCart();
   const { isAuthenticated, loggedUser } = useAuth();
   const router = useRouter();
   const [selectedQuantities, setSelectedQuantities] = useState<{ [key: string]: number }>({});
@@ -100,9 +100,30 @@ const Cart = ({ clientId }: { clientId: string }) => {
   const openPopover = Boolean(anchorEl);
   const popoverId = openPopover ? 'simple-popover' : undefined;
 
-  const handleEnviarPedido = () => {
-    console.log("Pedido enviado com sucesso!");
-    setOpenModal(false);
+  const handleEnviarPedido = async () => {
+    const order = {
+      customer: tempCadastro,
+      items: cart,
+      total: calculateTotal(),
+    };
+
+    try {
+      const response = await fetch(`/api/clients/${clientId}/orders`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(order),
+      });
+
+      if (response.ok) {
+        alert('Pedido enviado com sucesso!');
+        clearCart();
+        setOpenModal(false);
+      } else {
+        alert('Erro ao enviar pedido');
+      }
+    } catch (error) {
+      alert('Erro ao enviar pedido');
+    }
   };
 
   const handleChangeCadastro = (field: string, value: string) => {


### PR DESCRIPTION
## Summary
- add `/orders` API endpoint for clients
- allow checkout screen to send orders
- track orders in JSON files
- support clearing cart via context
- document new Orders API

## Testing
- `npm run build` *(fails: next not found)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6844e42e22b0832d80d6be701b935159